### PR TITLE
Use create_block_from_{coo,csc} instead of dgl.create_block

### DIFF
--- a/examples/test_create_block.py
+++ b/examples/test_create_block.py
@@ -1,0 +1,55 @@
+import torch
+from dgl import create_block
+from gs.utils import create_block_from_coo, create_block_from_csc
+
+
+def check_block(block1, block2):
+    assert (block1.adj_sparse('coo')[0].equal(block2.adj_sparse('coo')[0]))
+    assert (block1.adj_sparse('coo')[1].equal(block2.adj_sparse('coo')[1]))
+
+    assert (block1.adj_sparse('csr')[0].equal(block2.adj_sparse('csr')[0]))
+    assert (block1.adj_sparse('csr')[1].equal(block2.adj_sparse('csr')[1]))
+    assert (block1.adj_sparse('csr')[2].equal(block2.adj_sparse('csr')[2]))
+
+    assert (block1.adj_sparse('csc')[0].equal(block2.adj_sparse('csc')[0]))
+    assert (block1.adj_sparse('csc')[1].equal(block2.adj_sparse('csc')[1]))
+    assert (block1.adj_sparse('csc')[2].equal(block2.adj_sparse('csc')[2]))
+
+
+print("creat_block from csc")
+num_row = 4
+num_col = 2
+indptr = torch.tensor([0, 2, 3], device='cuda:0')
+indices = torch.tensor([2, 3, 0], device='cuda:0')
+
+print("dgl create_block")
+csc_block1 = create_block(('csc', (indptr, indices, [])),
+                          num_src_nodes=num_row,
+                          num_dst_nodes=num_col)
+
+print("our create_block")
+csc_block2 = create_block_from_csc(indptr,
+                                   indices,
+                                   torch.tensor([]),
+                                   num_src=num_row,
+                                   num_dst=num_col)
+
+print("check")
+check_block(csc_block1, csc_block2)
+
+print("creat_block from coo")
+num_row = 4
+num_col = 2
+row = torch.tensor([2, 3, 0], device='cuda:0')
+col = torch.tensor([0, 0, 1], device='cuda:0')
+
+print("dgl create_block")
+coo_block1 = create_block(('coo', (row, col)),
+                          num_src_nodes=num_row,
+                          num_dst_nodes=num_col)
+
+print("our create_block")
+coo_block2 = create_block_from_coo(row, col, num_src=num_row, num_dst=num_col)
+
+print("check")
+check_block(coo_block1, coo_block2)

--- a/python/gs/matrix_api/matrix.py
+++ b/python/gs/matrix_api/matrix.py
@@ -2,8 +2,11 @@ import torch
 from torch.fx import Proxy
 import dgl
 from dgl import DGLHeteroGraph, create_block
+from gs.utils import create_block_from_coo, create_block_from_csc
 
 torch.fx.wrap('create_block')
+torch.fx.wrap('create_block_from_coo')
+torch.fx.wrap('create_block_from_csc')
 
 
 class Matrix(object):
@@ -33,14 +36,16 @@ class Matrix(object):
         )
         block = None
         if format == 'coo':
-            block = create_block((format, (format_tensor1, format_tensor2)),
-                                 num_src_nodes=num_row,
-                                 num_dst_nodes=num_col)
+            block = create_block_from_coo(format_tensor1,
+                                          format_tensor2,
+                                          num_src=num_row,
+                                          num_dst=num_col)
         else:
-            block = create_block(
-                (format, (format_tensor1, format_tensor2, [])),
-                num_src_nodes=num_row,
-                num_dst_nodes=num_col)
+            block = create_block_from_csc(format_tensor1,
+                                          format_tensor2,
+                                          torch.tensor([]),
+                                          num_src=num_row,
+                                          num_dst=num_col)
 
         data = self._graph._CAPI_get_data()
         if data is not None:

--- a/python/gs/utils/__init__.py
+++ b/python/gs/utils/__init__.py
@@ -1,3 +1,5 @@
+import imp
 from .load_graph import load_reddit, load_ogbn_products
 from .model import ConvModel, GraphConv, SAGEConv
 from .dataloader import SeedGenerator
+from .to_dgl_block import create_block_from_coo, create_block_from_csc

--- a/python/gs/utils/to_dgl_block.py
+++ b/python/gs/utils/to_dgl_block.py
@@ -1,0 +1,23 @@
+import dgl
+from dgl.heterograph import DGLBlock
+
+
+def create_block_from_csc(indptr, indices, e_ids, num_src, num_dst):
+    hgidx = dgl.heterograph_index.create_unitgraph_from_csr(
+        2,
+        num_src,
+        num_dst,
+        indptr,
+        indices,
+        e_ids,
+        formats=['coo', 'csr', 'csc'],
+        transpose=True)
+    retg = DGLBlock(hgidx, (['_N'], ['_N']), ['_E'])
+    return retg
+
+
+def create_block_from_coo(row, col, num_src, num_dst):
+    hgidx = dgl.heterograph_index.create_unitgraph_from_coo(
+        2, num_src, num_dst, row, col, formats=['coo', 'csr', 'csc'])
+    retg = DGLBlock(hgidx, (['_N'], ['_N']), ['_E'])
+    return retg


### PR DESCRIPTION
*  create_block_from_{coo,csc} are supported. Compared with dgl.create_block, they have a smaller overhead.
```python
def create_block_from_csc(indptr, indices, e_ids, num_src, num_dst):
    hgidx = dgl.heterograph_index.create_unitgraph_from_csr(
        2,
        num_src,
        num_dst,
        indptr,
        indices,
        e_ids,
        formats=['coo', 'csr', 'csc'],
        transpose=True)
    retg = DGLBlock(hgidx, (['_N'], ['_N']), ['_E'])
    return retg


def create_block_from_coo(row, col, num_src, num_dst):
    hgidx = dgl.heterograph_index.create_unitgraph_from_coo(
        2, num_src, num_dst, row, col, formats=['coo', 'csr', 'csc'])
    retg = DGLBlock(hgidx, (['_N'], ['_N']), ['_E'])
    return retg
```

@Liu-rj Can you measure the overhead of the new create_block apis?