### PR TITLE
fix bug in sampling indptr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ gs.egg-info
 __pycache__
 *.nsys-rep
 third_party
+data

--- a/src/cuda/sampling_utils.h
+++ b/src/cuda/sampling_utils.h
@@ -10,25 +10,23 @@ namespace impl {
 template <typename IdType>
 torch::Tensor GetSampledSubIndptr(torch::Tensor indptr, int64_t fanout,
                                   bool replace) {
-  int64_t size = indptr.numel();
-  auto new_indptr = torch::zeros(size, indptr.options());
+  int64_t num_items = indptr.numel() - 1;
+  auto new_indptr = torch::zeros(num_items + 1, indptr.options());
 
   using it = thrust::counting_iterator<IdType>;
-  thrust::for_each(
-      thrust::device, it(0), it(size),
-      [in_indptr = indptr.data_ptr<IdType>(),
-       out = new_indptr.data_ptr<IdType>(), if_replace = replace,
-       num_fanout = fanout] __device__(int i) mutable {
-        IdType begin = in_indptr[i];
-        IdType end = in_indptr[i + 1];
-        if (if_replace) {
-          out[i] = (end - begin) == 0 ? 0 : num_fanout;
-        } else {
-          out[i] = min(end - begin, num_fanout);
-        }
-      });
-
-  cub_exclusiveSum<IdType>(new_indptr.data_ptr<IdType>(), size + 1);
+  thrust::for_each(thrust::device, it(0), it(num_items),
+                   [in_indptr = indptr.data_ptr<IdType>(),
+                    out = new_indptr.data_ptr<IdType>(), if_replace = replace,
+                    num_fanout = fanout] __device__(int i) mutable {
+                     IdType begin = in_indptr[i];
+                     IdType end = in_indptr[i + 1];
+                     if (if_replace) {
+                       out[i] = (end - begin) == 0 ? 0 : num_fanout;
+                     } else {
+                       out[i] = min(end - begin, num_fanout);
+                     }
+                   });
+  cub_exclusiveSum<IdType>(new_indptr.data_ptr<IdType>(), num_items + 1);
   return new_indptr;
 }
 
@@ -40,20 +38,19 @@ torch::Tensor GetSampledSubIndptrFused(torch::Tensor indptr,
   auto sub_indptr = torch::empty(size + 1, indptr.options());
 
   using it = thrust::counting_iterator<IdType>;
-  thrust::for_each(
-      thrust::device, it(0), it(size),
-      [in = column_ids.data_ptr<IdType>(),
-       in_indptr = indptr.data_ptr<IdType>(),
-       out = sub_indptr.data_ptr<IdType>(), if_replace = replace,
-       num_fanout = fanout] __device__(int i) mutable {
-        IdType begin = in_indptr[in[i]];
-        IdType end = in_indptr[in[i] + 1];
-        if (if_replace) {
-          out[i] = (end - begin) == 0 ? 0 : num_fanout;
-        } else {
-          out[i] = min(end - begin, num_fanout);
-        }
-      });
+  thrust::for_each(thrust::device, it(0), it(size),
+                   [in = column_ids.data_ptr<IdType>(),
+                    in_indptr = indptr.data_ptr<IdType>(),
+                    out = sub_indptr.data_ptr<IdType>(), if_replace = replace,
+                    num_fanout = fanout] __device__(int i) mutable {
+                     IdType begin = in_indptr[in[i]];
+                     IdType end = in_indptr[in[i] + 1];
+                     if (if_replace) {
+                       out[i] = (end - begin) == 0 ? 0 : num_fanout;
+                     } else {
+                       out[i] = min(end - begin, num_fanout);
+                     }
+                   });
 
   cub_exclusiveSum<IdType>(sub_indptr.data_ptr<IdType>(), size + 1);
   return sub_indptr;


### PR DESCRIPTION
Fix a bug in `torch::Tensor GetSampledSubIndptr(torch::Tensor indptr, int64_t fanout, bool replace)` which may throw `CUDA Error: illegal memory access` in the master version.