### PR TITLE
Add relabel option for slicing

### DIFF
--- a/examples/test.py
+++ b/examples/test.py
@@ -9,36 +9,38 @@ indices = torch.LongTensor([4, 0, 1, 2]).to('cuda:0')
 print('Test Case 1: +++++++++++++++++++')
 column_ids = torch.LongTensor([2, 3]).to('cuda:0')
 A._CAPI_load_csc(indptr, indices)
-subA = A.columnwise_slicing(column_ids)
-subA.print()
+m = Matrix(A)
+subA = m.columnwise_slicing(column_ids)
+print(subA._graph._CAPI_metadata())
 subA = subA.columnwise_sampling(2, True)
-subA.print()
-subA = A.fused_columnwise_slicing_sampling(column_ids, 2, True)
-subA.print()
+print(subA._graph._CAPI_metadata())
+subA = m.fused_columnwise_slicing_sampling(column_ids, 2, True)
+print(subA._graph._CAPI_metadata())
 
 print('Test Case 2: +++++++++++++++++++')
 column_ids = torch.LongTensor([1, 3]).to('cuda:0')
 A._CAPI_load_csc(indptr, indices)
-subA = A.columnwise_slicing(column_ids)
-subA.print()
-subA = subA.columnwise_sampling(2, True)
-subA.print()
-subA = A.fused_columnwise_slicing_sampling(column_ids, 2, True)
-subA.print()
-
-
-def sampling(A: Matrix):
-    column_ids = torch.LongTensor([2, 3]).to('cuda:0')
-    return A[:, column_ids]
-
-
 m = Matrix(A)
-compiled_func = gs.jit.compile(func=sampling, args=(m, ))
-print("\nOrigin:")
-sampling(m)._graph.print()
+subA = m.columnwise_slicing(column_ids)
+print(subA._graph._CAPI_metadata())
+subA = subA.columnwise_sampling(2, True)
+print(subA._graph._CAPI_metadata())
+subA = m.fused_columnwise_slicing_sampling(column_ids, 2, True)
+print(subA._graph._CAPI_metadata())
 
-print()
 
-print("\nCompiled:")
-print(compiled_func(m, ))
-compiled_func(m, )._graph.print()
+# def sampling(A: Matrix):
+#     column_ids = torch.LongTensor([2, 3]).to('cuda:0')
+#     return A[:, column_ids]
+
+
+# m = Matrix(A)
+# compiled_func = gs.jit.compile(func=sampling, args=(m, ))
+# print("\nOrigin:")
+# sampling(m)._graph.print()
+
+# print()
+
+# print("\nCompiled:")
+# print(compiled_func(m, ))
+# compiled_func(m, )._graph.print()

--- a/python/gs/matrix_api/matrix.py
+++ b/python/gs/matrix_api/matrix.py
@@ -64,13 +64,13 @@ class Matrix(object):
         return block
 
     def columnwise_slicing(self, t):
-        return Matrix(self._graph._CAPI_columnwise_slicing(t, _CSC, _COO))
+        return Matrix(self._graph._CAPI_slicing(t, 0, _CSC, _COO, False))
 
     def columnwise_sampling(self, fanout, replace=True, bias=None):
         if bias is None:
-            return Matrix(self._graph._CAPI_columnwise_sampling(fanout, replace, _CSC, _COO))
+            return Matrix(self._graph._CAPI_sampling(0, fanout, replace, _CSC, _COO))
         else:
-            return Matrix(self._graph._CAPI_columnwise_sampling_with_probs(bias, fanout, replace, _CSC, _COO))
+            return Matrix(self._graph._CAPI_sampling_with_probs(0, bias, fanout, replace, _CSC, _COO))
 
     def sum(self, axis, powk=1) -> torch.Tensor:
         if axis == 0:
@@ -99,10 +99,10 @@ class Matrix(object):
         c_slice = data[1]
 
         if isinstance(c_slice, Proxy) or isinstance(c_slice, torch.Tensor):
-            ret = ret._CAPI_columnwise_slicing(c_slice, _CSC, _COO)
+            ret = ret._CAPI_slicing(c_slice, 0, _CSC, _COO, False)
 
         if isinstance(r_slice, Proxy) or isinstance(r_slice, torch.Tensor):
-            ret = ret._CAPI_rowwise_slicing(r_slice, _CSR, _COO)
+            ret = ret._CAPI_slicing(r_slice, 0, _CSR, _COO, False)
 
         return Matrix(ret)
 

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -135,31 +135,35 @@ void Graph::SetNumEdges(int64_t num_edges) { num_edges_ = num_edges; }
 // axis = 0 for col; axis = 1 for row.
 c10::intrusive_ptr<Graph> Graph::Slicing(torch::Tensor n_ids, int64_t axis,
                                          int64_t on_format,
-                                         int64_t output_format) {
+                                         int64_t output_format, bool relabel) {
   CreateSparseFormat(on_format);
   std::shared_ptr<COO> coo_ptr;
+  std::shared_ptr<CSC> csc_ptr;
+  std::shared_ptr<CSR> csr_ptr;
   std::shared_ptr<_TMP> tmp_ptr;
   torch::Tensor select_index;
-  torch::optional<torch::Tensor> e_ids;
+  torch::optional<torch::Tensor> e_ids, new_col_ids, new_row_ids, new_val_cols,
+      new_val_rows;
+  int64_t new_num_cols, new_num_rows, new_num_edges;
   bool with_coo = output_format & _COO;
 
-  c10::intrusive_ptr<Graph> ret;
   if (axis == 0) {
-    auto new_col_ids =
+    new_col_ids =
         col_ids_.has_value() ? col_ids_.value().index({n_ids}) : n_ids;
-    ret = c10::intrusive_ptr<Graph>(std::unique_ptr<Graph>(
-        new Graph(true, new_col_ids, row_ids_, n_ids.numel(), num_rows_)));
+    new_row_ids = row_ids_;
+    new_num_cols = n_ids.numel();
+    new_num_rows = num_rows_;
   } else {
-    auto new_row_ids =
+    new_col_ids = col_ids_;
+    new_row_ids =
         row_ids_.has_value() ? row_ids_.value().index({n_ids}) : n_ids;
-    ret = c10::intrusive_ptr<Graph>(std::unique_ptr<Graph>(
-        new Graph(true, col_ids_, new_row_ids, num_cols_, n_ids.numel())));
+    new_num_cols = num_cols_;
+    new_num_rows = n_ids.numel();
   }
 
   if (on_format == _COO) {
     std::tie(coo_ptr, select_index) = COOColSlicing(coo_, n_ids, axis);
-    ret->SetCOO(coo_ptr);
-    ret->SetNumEdges(coo_ptr->row.numel());
+    new_num_edges = coo_ptr->row.numel();
     e_ids = coo_->e_ids;
 
   } else if (on_format == _CSC || on_format == _DCSC) {
@@ -174,20 +178,33 @@ c10::intrusive_ptr<Graph> Graph::Slicing(torch::Tensor n_ids, int64_t axis,
             DCSCColSlicing(csc_, val_col_ids_.value(), n_ids, with_coo);
       else
         std::tie(tmp_ptr, select_index) = CSCColSlicing(csc_, n_ids, with_coo);
+
+      if (relabel) {
+        torch::Tensor frontier;
+        std::vector<torch::Tensor> relabeled_result;
+        std::tie(frontier, relabeled_result) = BatchTensorRelabel(
+            {tmp_ptr->coo_in_indices}, {tmp_ptr->coo_in_indices});
+        tmp_ptr->coo_in_indices = relabeled_result[0];
+        new_row_ids = frontier;
+        new_num_rows = frontier.numel();
+      }
     } else {
       // for row
       std::tie(tmp_ptr, select_index) = CSCRowSlicing(csc_, n_ids, with_coo);
-      if (val_col_ids_.has_value()) ret->SetValidCols(val_col_ids_.value());
+      new_val_cols = val_col_ids_;
+
+      if (relabel)
+        LOG(FATAL) << "Not implemented warning";
     }
 
     if (output_format & _CSC)
-      ret->SetCSC(std::make_shared<CSC>(
-          CSC{tmp_ptr->indptr, tmp_ptr->coo_in_indices, torch::nullopt}));
+      csc_ptr = std::make_shared<CSC>(
+          CSC{tmp_ptr->indptr, tmp_ptr->coo_in_indices, torch::nullopt});
     if (output_format & _COO)
-      ret->SetCOO(std::make_shared<COO>(COO{tmp_ptr->coo_in_indices,
-                                            tmp_ptr->coo_in_indptr,
-                                            torch::nullopt, false, true}));
-    ret->SetNumEdges(tmp_ptr->coo_in_indices.numel());
+      coo_ptr = std::make_shared<COO>(COO{tmp_ptr->coo_in_indices,
+                                          tmp_ptr->coo_in_indptr,
+                                          torch::nullopt, false, true});
+    new_num_edges = tmp_ptr->coo_in_indices.numel();
     e_ids = csc_->e_ids;
 
   } else if (on_format == _CSR || on_format == _DCSR) {
@@ -198,28 +215,48 @@ c10::intrusive_ptr<Graph> Graph::Slicing(torch::Tensor n_ids, int64_t axis,
     if (axis == 0) {
       // for col
       std::tie(tmp_ptr, select_index) = CSCRowSlicing(csr_, n_ids, with_coo);
-      if (val_row_ids_.has_value()) ret->SetValidRows(val_row_ids_.value());
-
+      new_val_rows = val_row_ids_;
+      
+      if (relabel)
+        LOG(FATAL) << "Not implemented warning";
     } else {
       if (val_row_ids_.has_value())
         std::tie(tmp_ptr, select_index) =
             DCSCColSlicing(csr_, val_row_ids_.value(), n_ids, with_coo);
       else
         std::tie(tmp_ptr, select_index) = CSCColSlicing(csr_, n_ids, with_coo);
+
+      if (relabel) {
+        torch::Tensor frontier;
+        std::vector<torch::Tensor> relabeled_result;
+        std::tie(frontier, relabeled_result) = BatchTensorRelabel(
+            {tmp_ptr->coo_in_indices}, {tmp_ptr->coo_in_indices});
+        tmp_ptr->coo_in_indices = relabeled_result[0];
+        new_col_ids = frontier;
+        new_num_cols = frontier.numel();
+      }
     }
 
     if (output_format & _CSR)
-      ret->SetCSR(std::make_shared<CSR>(
-          CSR{tmp_ptr->indptr, tmp_ptr->coo_in_indices, torch::nullopt}));
+      csr_ptr = std::make_shared<CSR>(
+          CSR{tmp_ptr->indptr, tmp_ptr->coo_in_indices, torch::nullopt});
     if (output_format & _COO)
-      ret->SetCOO(std::make_shared<COO>(COO{tmp_ptr->coo_in_indptr,
-                                            tmp_ptr->coo_in_indices,
-                                            torch::nullopt, true, false}));
-    ret->SetNumEdges(tmp_ptr->coo_in_indices.numel());
+      coo_ptr = std::make_shared<COO>(COO{tmp_ptr->coo_in_indptr,
+                                          tmp_ptr->coo_in_indices,
+                                          torch::nullopt, true, false});
+    new_num_edges = tmp_ptr->coo_in_indices.numel();
     e_ids = csr_->e_ids;
   } else {
     LOG(FATAL) << "Not implemented warning";
   }
+  auto ret = c10::intrusive_ptr<Graph>(std::unique_ptr<Graph>(
+      new Graph(true, new_col_ids, new_row_ids, new_num_cols, new_num_rows)));
+  ret->SetNumEdges(new_num_edges);
+  ret->SetCOO(coo_ptr);
+  ret->SetCSC(csc_ptr);
+  ret->SetCSR(csr_ptr);
+  if (new_val_cols.has_value()) ret->SetValidCols(new_val_cols.value());
+  if (new_val_rows.has_value()) ret->SetValidRows(new_val_rows.value());
   if (data_.has_value()) {
     torch::Tensor out_data, data_index;
     if (e_ids.has_value())

--- a/src/graph.cc
+++ b/src/graph.cc
@@ -216,7 +216,7 @@ c10::intrusive_ptr<Graph> Graph::Slicing(torch::Tensor n_ids, int64_t axis,
       // for col
       std::tie(tmp_ptr, select_index) = CSCRowSlicing(csr_, n_ids, with_coo);
       new_val_rows = val_row_ids_;
-      
+
       if (relabel)
         LOG(FATAL) << "Not implemented warning";
     } else {
@@ -754,7 +754,7 @@ std::vector<torch::Tensor> Graph::MetaData() {
                           torch::dtype(torch::kFloat32).device(torch::kCUDA));
     return {col_ids, row_ids, data, csr_->indptr, csr_->indices};
   } else {
-    LOG(FATAL) << "Error in MetaData: no CSC nor CSR.";
+    LOG(INFO) << "Warning in MetaData: no CSC nor CSR.";
     return {coo_->row, coo_->col};
   }
 }

--- a/src/graph.h
+++ b/src/graph.h
@@ -46,7 +46,8 @@ class Graph : public torch::CustomClassHolder {
   c10::intrusive_ptr<Graph> FusedBidirSlicing(torch::Tensor column_seeds,
                                               torch::Tensor row_seeds);
   c10::intrusive_ptr<Graph> Slicing(torch::Tensor n_ids, int64_t axis,
-                                    int64_t on_format, int64_t output_format);
+                                    int64_t on_format, int64_t output_format,
+                                    bool relabel = false);
   c10::intrusive_ptr<Graph> Sampling(int64_t axis, int64_t fanout, bool replace,
                                      int64_t on_format, int64_t output_format);
   c10::intrusive_ptr<Graph> SamplingProbs(int64_t axis,

--- a/tests/test_relabel.cc
+++ b/tests/test_relabel.cc
@@ -4,7 +4,7 @@
 
 using namespace gs;
 
-TEST(ColwiseSlicingRelabel, test1)
+TEST(SlicingRelabel, test1)
 {
     Graph A(false);
     auto options = torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA);
@@ -23,4 +23,27 @@ TEST(ColwiseSlicingRelabel, test1)
     auto csc_ptr = subA->GetCSC();
     EXPECT_TRUE(csc_ptr->indptr.equal(torch::arange(0, 4, options) * 5));
     EXPECT_TRUE(csc_ptr->indices.equal(torch::arange(0, 15, options)));
+}
+
+TEST(SlicingRelabel, test2)
+{
+    Graph A(false);
+    auto options = torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA);
+    torch::Tensor indptr = torch::cat({torch::zeros(10, options), torch::arange(0, 3, options) * 2});
+    torch::Tensor indices = torch::arange(5, 7, options).repeat({2});
+    torch::Tensor expected_indices = torch::arange(0, 2, options);
+    A.LoadCSC(indptr, indices);
+    A.CSC2DCSR();
+
+    torch::Tensor row_ids = torch::arange(5, 6, options);
+    auto subA = A.Slicing(row_ids, 1, _DCSR, _CSR, true);
+    EXPECT_EQ(A.GetNumCols(), 12);
+    EXPECT_EQ(A.GetNumRows(), 12);
+    EXPECT_EQ(subA->GetNumCols(), 2);
+    EXPECT_EQ(subA->GetNumRows(), 1);
+
+    auto csr_ptr = subA->GetCSR();
+    EXPECT_EQ(csr_ptr->indptr.numel(), 2);
+    EXPECT_EQ(csr_ptr->indices.numel(), 2);
+    EXPECT_TRUE(csr_ptr->indices.equal(expected_indices));
 }

--- a/tests/test_relabel.cc
+++ b/tests/test_relabel.cc
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+#include "graph.h"
+#include <torch/torch.h>
+
+using namespace gs;
+
+TEST(ColwiseSlicingRelabel, test1)
+{
+    Graph A(false);
+    auto options = torch::TensorOptions().dtype(torch::kInt64).device(torch::kCUDA);
+    torch::Tensor col_ids = torch::arange(0, 20, options);
+    torch::Tensor indptr = torch::arange(0, 21, options) * 5;
+    torch::Tensor indices = torch::arange(0, 100, options);
+    A.LoadCSCWithColIds(col_ids, indptr, indices);
+
+    torch::Tensor ids = torch::arange(1, 4, options);
+    auto subA = A.Slicing(ids, 0, _CSC, _CSC, true);
+    EXPECT_EQ(A.GetNumCols(), 20);
+    EXPECT_EQ(A.GetNumRows(), 100);
+    EXPECT_EQ(subA->GetNumCols(), 3);
+    EXPECT_EQ(subA->GetNumRows(), 15);
+
+    auto csc_ptr = subA->GetCSC();
+    EXPECT_TRUE(csc_ptr->indptr.equal(torch::arange(0, 4, options) * 5));
+    EXPECT_TRUE(csc_ptr->indices.equal(torch::arange(0, 15, options)));
+}


### PR DESCRIPTION
Currently, `Relabel` for slicing with `CSC/DCSC on axis=0` and `CSR/DCSR on axis=1` is supported.